### PR TITLE
fix a bug of not updating enthalpy for BL99

### DIFF
--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -1030,12 +1030,12 @@
          endif
 
 ! echmod: is this necessary?
-!         if (ktherm == 1) then
-!               if (zTin(k)>= -zSin(k)*depressT) then
-!                   zTin(k) = -zSin(k)*depressT - puny
-!                   zqin(k) = -rhoi*cp_ocn*zSin(k)*depressT
-!               endif
-!         endif
+         if (ktherm == 1) then
+               if (zTin(k)>= -zSin(k)*depressT) then
+                   zTin(k) = -zSin(k)*depressT - puny
+                   zqin(k) = -rhoi*cp_ocn*zSin(k)*depressT
+               endif
+         endif
 
       !-----------------------------------------------------------------
       ! initial energy per unit area of ice/snow, relative to 0 C


### PR DESCRIPTION
This PR uncommented some code to fix a bug in init_vertical_profile when ktherm == 1. The bug is causing coupled model to crash occasionally.  