### PR TITLE
enable mushy layer thermodynamics scheme

### DIFF
--- a/columnphysics/icepack_therm_mushy.F90
+++ b/columnphysics/icepack_therm_mushy.F90
@@ -24,8 +24,11 @@
 #ifdef GEOSCOUPLED
   use icepack_therm_shared, only: dfsurfdts_cpl,      & !
                                   dflatdts_cpl,       & !
+                                  flat_cpl0,          & !
+                                  fsurf_cpl0,         & !
                                   fsurf_cpl,          & !
                                   flat_cpl              !
+  use icepack_therm_shared, only: ismyturn
 #endif
 
   implicit none
@@ -872,6 +875,11 @@
     else
        ! initially melting
 
+#ifdef GEOSCOUPLED
+       fsurf_cpl = fsurf_cpl + dfsurfdts_cpl * (Tmlt - Tsf)
+       flat_cpl  = flat_cpl  + dflatdts_cpl  * (Tmlt - Tsf)
+#endif
+
        ! solve the system for melt and no snow
        Tsf = Tmlt
 
@@ -916,6 +924,11 @@
           ! assume surface is cold
           fcondtop1 = fcondtop
           fsurfn1   = fsurfn
+
+#ifdef GEOSCOUPLED
+          fsurf_cpl = fsurf_cpl0
+          flat_cpl  = flat_cpl0
+#endif
 
           ! reset the solution to initial values
           Tsf  = Tsf0

--- a/columnphysics/icepack_therm_shared.F90
+++ b/columnphysics/icepack_therm_shared.F90
@@ -36,6 +36,7 @@
                 icepack_liquidus_temperature, &
                 icepack_sea_freezing_temperature, &
                 icepack_enthalpy_snow, &
+                ismyturn, &
                 adjust_enthalpy
 
       real (kind=dbl_kind), parameter, public :: &
@@ -55,8 +56,13 @@
       real (kind=dbl_kind), public :: &
          dfsurfdts_cpl,      & !
          dflatdts_cpl,       & !
+         fsurf_cpl0,         & !
+         flat_cpl0,          & !
          fsurf_cpl,          & !
          flat_cpl              !
+
+      integer(kind=int_kind), public :: &
+         local_tsk, local_i, local_j, local_blk
 #endif
 
 !=======================================================================
@@ -549,6 +555,16 @@
       enddo                     ! k
 
       end subroutine adjust_enthalpy
+
+      function ismyturn() result(ret)
+
+         logical(kind=log_kind) :: ret
+
+         ret = (local_tsk == 38 .and. local_i == 5 .and. &
+                local_j == 53 .and. local_blk == 1)
+
+      end function ismyturn
+
 
 !=======================================================================
 

--- a/columnphysics/icepack_therm_shared.F90
+++ b/columnphysics/icepack_therm_shared.F90
@@ -36,7 +36,9 @@
                 icepack_liquidus_temperature, &
                 icepack_sea_freezing_temperature, &
                 icepack_enthalpy_snow, &
+#ifdef GEOSCOUPLED
                 ismyturn, &
+#endif
                 adjust_enthalpy
 
       real (kind=dbl_kind), parameter, public :: &

--- a/columnphysics/icepack_therm_shared.F90
+++ b/columnphysics/icepack_therm_shared.F90
@@ -556,6 +556,7 @@
 
       end subroutine adjust_enthalpy
 
+#ifdef GEOSCOUPLED
       function ismyturn() result(ret)
 
          logical(kind=log_kind) :: ret
@@ -564,6 +565,7 @@
                 local_j == 53 .and. local_blk == 1)
 
       end function ismyturn
+#endif
 
 
 !=======================================================================

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -40,8 +40,15 @@
 #ifdef GEOSCOUPLED
       use icepack_therm_shared, only: dfsurfdts_cpl,      & !
                                       dflatdts_cpl,       & !
+                                      flat_cpl0,          & !
+                                      fsurf_cpl0,         & !
                                       fsurf_cpl,          & !
                                       flat_cpl              !
+      use icepack_therm_shared, only: local_tsk,      & !
+                                      local_i,        & !
+                                      local_j,        & !
+                                      ismyturn,       &
+                                      local_blk
 #endif
       use icepack_therm_bl99,   only: temperature_changes
       use icepack_therm_mushy,  only: temperature_changes_salinity
@@ -314,6 +321,22 @@
       dflatdts_cpl  = dflatdt_in
       fsurf_cpl     = fsurfn_in
       flat_cpl      = flatn_in
+      fsurf_cpl0    = fsurfn_in
+      flat_cpl0     = flatn_in
+
+      if(present(my_tsk)) then
+          local_tsk = my_tsk
+      endif
+      if(present(my_i)) then
+          local_i = my_i
+      endif
+      if(present(my_j)) then
+          local_j = my_j
+      endif
+      if(present(my_blk)) then
+          local_blk = my_blk
+      endif
+
 #endif
 
       if (calc_Tsfc) then
@@ -987,6 +1010,8 @@
             call icepack_warnings_add(warnstr)
 
             if (ktherm == 2) then
+               write(warnstr,*) subname, 'tsk, i, j', local_tsk, local_i, local_j
+               call icepack_warnings_add(warnstr)
                zqin(k) = enthalpy_of_melting(zSin(k)) - c1
                zTin(k) = icepack_mushy_temperature_mush(zqin(k),zSin(k))
                write(warnstr,*) subname, 'Corrected quantities'
@@ -995,6 +1020,7 @@
                call icepack_warnings_add(warnstr)
                write(warnstr,*) subname, 'zTin=',zTin(k)
                call icepack_warnings_add(warnstr)
+               tice_high = .false.
             else
                call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
                call icepack_warnings_add(subname//" init_vertical_profile: Starting thermo, zTin > Tmax, layer" )
@@ -2973,6 +2999,14 @@
 
             if (icepack_warnings_aborted(subname)) then
                write(warnstr,*) subname, ' ice: Vertical thermo error, cat ', n
+               call icepack_warnings_add(warnstr)
+               write(warnstr,*) subname, ' ice: Vertical thermo error, my_tsk ', my_tsk
+               call icepack_warnings_add(warnstr)
+               write(warnstr,*) subname, ' ice: Vertical thermo error, my_i ', my_i
+               call icepack_warnings_add(warnstr)
+               write(warnstr,*) subname, ' ice: Vertical thermo error, my_j ', my_j
+               call icepack_warnings_add(warnstr)
+               write(warnstr,*) subname, ' ice: Vertical thermo error, my_blk ', my_blk
                call icepack_warnings_add(warnstr)
                return
             endif

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -1010,8 +1010,6 @@
             call icepack_warnings_add(warnstr)
 
             if (ktherm == 2) then
-               write(warnstr,*) subname, 'tsk, i, j', local_tsk, local_i, local_j
-               call icepack_warnings_add(warnstr)
                zqin(k) = enthalpy_of_melting(zSin(k)) - c1
                zTin(k) = icepack_mushy_temperature_mush(zqin(k),zSin(k))
                write(warnstr,*) subname, 'Corrected quantities'


### PR DESCRIPTION
This PR adds support for running ```mushy layer``` thermodynamics scheme in coupled mode. The code is in place but the scheme needs to be tested in long climate runs before ```mushy layer``` can be set as default.