### PR TITLE
do not correct zqsn in condensation step when ktherm=2

### DIFF
--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -1344,8 +1344,10 @@
          if (hstot > puny) then
             zqsn(1) =  (dzs(1) * zqsn(1) &
                           + dhs * zqsnew) / hstot
+            if (ktherm < 2) then
                ! avoid roundoff errors
-            zqsn(1) = min(zqsn(1), -rhos*Lfresh)
+               zqsn(1) = min(zqsn(1), -rhos*Lfresh)
+            endif
          endif
 #endif
          dzs(1) = dzs(1) + dhs


### PR DESCRIPTION
This PR fixed a bug of correcting snow enthalpy```zqsn(1)``` prematurely when ```ktherm=2```. 

In 1440x1080 configuration, snow layer sometimes could get above freezing when ```mushy layer``` scheme is used. There is no check for such condition in the thermo solver. Instead, ```thickness_change``` subroutine handles such case in an energy and mass conserving manner
https://github.com/GEOS-ESM/Icepack/blob/008f5f697b7aac319251845420d51b08c2c54d03/columnphysics/icepack_therm_vertical.F90#L1314-L1336

In GEOS coupling, when condensation happens over snow, there is a line to correct round-off error of updated top snow layer enthalpy ```zqsn(1)```
https://github.com/GEOS-ESM/Icepack/blob/abbbd626c5c48121ad02ceff125d341ae9f37f62/columnphysics/icepack_therm_vertical.F90#L1347-L1348

This correction is supposed to be for **round-off**, not for the above freezing case as seen in ```mushy layer``` scheme. **Note: for ```BL99```, snow layer temperature never gets above freezing so the correction is valid here**. If ```mushy layer``` scheme applies this correction, energy is not conserved and the model will crash in conservation check.  So an ```if``` condition is added here to only apply correction for ```BL99``` scheme. In ```mushy layer```, the correction is done as above ⬆️.
   
Zero-diff for AMIP and coupled runs using CICE4 sea ice model 